### PR TITLE
TagBase.delete_tags

### DIFF
--- a/feedly/api_client/data.py
+++ b/feedly/api_client/data.py
@@ -76,6 +76,24 @@ class TagBase(Streamable):
         self._client.do_api_request(f'/v3/tags/{quote_plus(self["id"])}', method='put',
                                     data={'entryIds': [entry_id for entry_id in entry_ids]})
 
+    def delete_tags(self, options: StreamOptions = None):
+        """
+        *** WARNING *** Non-reversible operation
+        Given a TagBas Streamable, remove tags corresponding to this tag stream, whichever user saved it, for
+        all articles downloaded with options StreamOptions.
+        :param options: specify high max_count to empty the board.
+        :return:
+        """
+        a_ids = [a["id"] for a in self.stream_contents(options)]
+        tag_id = self._get_id()
+        while len(a_ids) > 0:
+            batch_size = 50  # limitation due to the url length: articles are "de-tagged" by batch of 10.
+            to_delete = a_ids[:batch_size]
+            a_ids = a_ids[batch_size:]
+            self._client.do_api_request(
+                f'/v3/tags/{quote_plus(tag_id)}/{",".join([quote_plus(d) for d in to_delete])}', method='DELETE'
+            )
+
 
 class UserCategory(Streamable):
 

--- a/feedly/api_client/data.py
+++ b/feedly/api_client/data.py
@@ -79,15 +79,16 @@ class TagBase(Streamable):
     def delete_tags(self, options: StreamOptions = None):
         """
         *** WARNING *** Non-reversible operation
-        Given a TagBas Streamable, remove tags corresponding to this tag stream, whichever user saved it, for
-        all articles downloaded with options StreamOptions.
+        Given a TagBase Streamable, remove tags corresponding to this tag stream, for all articles downloaded
+        with options StreamOptions. If User is part of a Team, this will also delete the teammate tags that correspond
+        to this board
         :param options: specify high max_count to empty the board.
         :return:
         """
         a_ids = [a["id"] for a in self.stream_contents(options)]
         tag_id = self._get_id()
         while len(a_ids) > 0:
-            batch_size = 50  # limitation due to the url length: articles are "de-tagged" by batch of 10.
+            batch_size = 50  # limitation due to the url length: articles are "de-tagged" by batch of 50.
             to_delete = a_ids[:batch_size]
             a_ids = a_ids[batch_size:]
             self._client.do_api_request(
@@ -328,7 +329,7 @@ class FeedlyUser(FeedlyData):
                     if tagged_by_user == self['id']:
                         a_ids += [a["id"]]
         while len(a_ids)>0:
-            batch_size = 10  # limitation due to the url length: articles are "de-tagged" by batch of 10.
+            batch_size = 50  # limitation due to the url length: articles are "de-tagged" by batch of 50.
             to_delete = a_ids[:batch_size]
             a_ids = a_ids[batch_size:]
             self._client.do_api_request(


### PR DESCRIPTION
Context:

We want to resort articles in a board.
To do that we first need to delete them, and re-tag them in the good order.
This should be done regardless of who saved the articles.

Compared to FeedlyUser.delete_tags, which worked on any streamable, and remove all tags that the user calling the method had created, TagBase.delete_tags removes only one tag per article, the tag corresponding to the id of TagBase, and that regardless of the user id.