### PR TITLE
[FeedlyUser] factorize lazy streams and add simple examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+feedly/examples/auth/*
+feedly/examples/results/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-feedly/examples/auth/*
 feedly/examples/results/*
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ but will get you going.
 If you're serious about building an app, you probably want to get a
  [developer token](https://developers.feedly.com/v3/developer/). Check the page for more details.
 
-You can run [feedly/examples/setup_auth.py](feedly/examples/setup_auth.py) to get your access token saved into the default config directory, `~.config/feedly`. Then, you can initialize the client as follows:
+You can run [feedly/examples/setup_auth.py](feedly/examples/setup_auth.py) to get your access token saved into the default config directory, `~/.config/feedly`. Then, you can initialize the client as follows:
 
 ```
 from feedly.api_client.session import FeedlySession

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ or you can create a new one when needed. It's a bit more efficient to keep it ar
 do choose to create clients as needed, you should pass in the user's ID in the constructor, 
 otherwise you'll incur a `/v3/profile` request. 
 
+## Examples setup
+
+To run [the examples](feedly/examples), you need first need to create a file containing you token in [feedly/examples/auth/access.token](feedly/examples/auth/access.token). You can also put your refresh token in [feedly/examples/auth/refresh.token](feedly/examples/auth/refresh.token).
+
 ## API Oriented Usage
 You can use the `FeedlySession` object to make arbitrary API requests. E.g.:
 
@@ -40,6 +44,7 @@ sess.do_api_request('/v3/feeds/feed%2Fhttp%3A%2F%2Fblog.feedly.com%2Ffeed%2F')
   ...
 }
 ```
+
 
 ## Object Oriented Usage
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ It's not necessary to list categories beforehand, if you know the ones that exis
 get one on the fly, by querying it by id or name:
 ```python
 sess.user.user_categories.get('comics')  # From the category name
-sess.user.user_categories.get('xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx')  # From the category id
+sess.user.user_categories.get('aaa')  # From the category id
 ```
 ```
-<UserCategory: user/xxx/category/comics>
+<UserCategory: user/xxx/category/aaa>
 ```
 
 You can access:
- - User categories with `sess.user.user_categories`
- - User tags with `sess.user.user_tags`
- - Enterprise categories with `sess.user.enterprise_categories`
- - User categories with `sess.user.enterprise_tags`
+ - User feeds with `sess.user.user_categories`
+ - User boards with `sess.user.user_tags`
+ - Team feeds with `sess.user.enterprise_categories`
+ - Team boards with `sess.user.enterprise_tags`
 
 
 #### Accessing Entries (articles)

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ otherwise you'll incur a `/v3/profile` request.
 ## API Oriented Usage
 You can use the `FeedlySession` object to make arbitrary API requests. E.g.:
 
-```
+```python
 sess.do_api_request('/v3/feeds/feed%2Fhttp%3A%2F%2Fblog.feedly.com%2Ffeed%2F')
-
-------------------
-
+```
+```json
 {
   "id": "feed/http://blog.feedly.com/feed/",
   "feedId": "feed/http://blog.feedly.com/feed/",
@@ -44,43 +43,50 @@ sess.do_api_request('/v3/feeds/feed%2Fhttp%3A%2F%2Fblog.feedly.com%2Ffeed%2F')
 
 ## Object Oriented Usage
 
-#### Retrieving Articles
-Alternatively, you can use the object oriented code, which facilitates common usage patterns.
+#### Retrieving Streams
+Alternatively, you can use the object-oriented code, which facilitates common usage patterns.
 E.g. you can list your user categories:
 ```
-sess.user.get_categories()
+sess.user.user_categories.name2stream
+```
 
-------------------
-
-{'comics': <UserCategory: user/xxx/category/comics>,
- 'econ': <UserCategory: user/xxx/category/econ>,
- 'global.must': <UserCategory: user/xxx/category/global.must>,
- 'politics': <UserCategory: user/xxx/category/politics>,
+```json
+{'comics': <UserCategory: user/xxx/category/aaa>,
+ 'econ': <UserCategory: user/xxx/category/bbb>,
+ 'global.must': <UserCategory: user/xxx/category/ccc>,
+ 'politics': <UserCategory: user/xxx/category/ddd>,
 }
 ```
 where `xxx` is your actual user ID.
 
 It's not necessary to list categories beforehand, if you know the ones that exist, you can 
-get one on the fly:
+get one on the fly, by querying it by id or name:
+```python
+sess.user.user_categories.get('comics')  # From the category name
+sess.user.user_categories.get('xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx')  # From the category id
 ```
-sess.user.get_category('comics'))
-
-------------------
-
+```
 <UserCategory: user/xxx/category/comics>
 ```
+
+You can access:
+ - User categories with `sess.user.user_categories`
+ - User tags with `sess.user.user_tags`
+ - Enterprise categories with `sess.user.enterprise_categories`
+ - User categories with `sess.user.enterprise_tags`
+
 
 #### Accessing Entries (articles)
 If you need to access entries or entry IDs, you can use easily stream them via `stream_contents`
 and `stream_ids`, respectively:
 
-```
+```python
 with FeedlySession(auth_token=token) as sess:
-    for eid in sess.user.get_category('politics').stream_ids():
+    for eid in sess.user.user_categories.get('politics').stream_ids():
          print(eid)
 
-------------------
-
+```
+```
 Dz51gkBgvGUvFOfTATCYLB2uqVaBIaGGazzxpZh2WL0=_16549c827dd:1645ba:3da9d93
 Dz51gkBgvGUvFOfTATCYLB2uqVaBIaGGazzxpZh2WL0=_16549c827dd:1645bb:3da9d93
 Z/Hzx8NYfSSE8sweA2v5+4r5h7HC5ALdE2YGYB8MYbQ=_1654a26f3fe:79d9ef9:6f86c10b
@@ -91,7 +97,7 @@ Take note of the `StreamOptions` class. There are important `max_count` and `cou
 properties that control streaming. To download all items, something like this could
 be done:
 
-```
+```python
 opts = StreamOptions(max_count=sys.maxsize) # down all items that exist
 opts.count = sys.maxsize # download as many items as possible in every API request
 with FeedlySession(auth_token=token) as sess:
@@ -101,7 +107,7 @@ with FeedlySession(auth_token=token) as sess:
 ```
 
 #### Tagging Existing Entries
-```
+```python
 with FeedlySession(auth_token=token) as sess:
     sess.user.get_tag('politics').tag_entry(eid)
 ```

--- a/README.md
+++ b/README.md
@@ -11,15 +11,12 @@ but will get you going.
 If you're serious about building an app, you probably want to get a
  [developer token](https://developers.feedly.com/v3/developer/). Check the page for more details.
 
-If we assume you saved the token value in a `access.token` file in your home directory, you can
-initalize the client as follows:
+You can run [feedly/examples/setup_auth.py](feedly/examples/setup_auth.py) to get your access token saved into the default config directory, `~.config/feedly`. Then, you can initialize the client as follows:
 
 ```
-from pathlib import Path
 from feedly.api_client.session import FeedlySession
 
-token = (Path.home() / 'access.token').read_text().strip()
-sess = FeedlySession(token)
+sess = FeedlySession()
 ```
 Clients are lightweight -- you can keep a client around for the lifetime of your program,
 or you can create a new one when needed. It's a bit more efficient to keep it around. If you
@@ -28,7 +25,7 @@ otherwise you'll incur a `/v3/profile` request.
 
 ## Examples setup
 
-To run [the examples](feedly/examples), you need first need to create a file containing you token in [feedly/examples/auth/access.token](feedly/examples/auth/access.token). You can also put your refresh token in [feedly/examples/auth/refresh.token](feedly/examples/auth/refresh.token).
+When running [an example](feedly/examples), for the first time, you'll be prompted to enter your token. It will be saved in ~/.config/feedly
 
 ## API Oriented Usage
 You can use the `FeedlySession` object to make arbitrary API requests. E.g.:
@@ -105,7 +102,7 @@ be done:
 ```python
 opts = StreamOptions(max_count=sys.maxsize) # down all items that exist
 opts.count = sys.maxsize # download as many items as possible in every API request
-with FeedlySession(auth_token=token) as sess:
+with FeedlySession() as sess:
     for eid in sess.user.get_category('politics').stream_ids(opts):
          print(eid)
 
@@ -113,7 +110,7 @@ with FeedlySession(auth_token=token) as sess:
 
 #### Tagging Existing Entries
 ```python
-with FeedlySession(auth_token=token) as sess:
+with FeedlySession() as sess:
     sess.user.get_tag('politics').tag_entry(eid)
 ```
 

--- a/feedly/api_client/data.py
+++ b/feedly/api_client/data.py
@@ -213,7 +213,7 @@ class LazyStreams(Generic[StreamableT]):
 
         try:
             return self.get_from_id(name_or_id)
-        except KeyError:
+        except ValueError:
             return self.get_from_name(name_or_id)
 
     def get_from_name(self, name: str) -> StreamableT:

--- a/feedly/api_client/data.py
+++ b/feedly/api_client/data.py
@@ -225,7 +225,7 @@ class LazyStreams(Generic[StreamableT]):
         return self.id2stream[id]
 
     def make_stream_from_id(self, uuid: str) -> StreamableT:
-        return self.factory({"id": "/".join(self.parts + [uuid])})
+        return self.factory({"id": "/".join(self.parts + [uuid])}, self.client)
 
 
 class FeedlyUser(FeedlyData):

--- a/feedly/api_client/enterprise/indicators_of_compromise.py
+++ b/feedly/api_client/enterprise/indicators_of_compromise.py
@@ -1,0 +1,73 @@
+import uuid
+from datetime import datetime
+from typing import Dict, List, Optional
+from urllib.parse import parse_qs
+
+from feedly.api_client.data import Streamable
+from feedly.api_client.session import FeedlySession
+
+
+class IoCDownloader:
+    RELATIVE_URL = "/v3/enterprise/ioc"
+
+    def __init__(self, session: FeedlySession, newer_than: Optional[datetime] = None):
+        """
+        Use this class to export the contextualized IoCs from a stream.
+        Enterprise/personals feeds/boards are supported (see dedicated methods below).
+        The IoCs will be returned along with their context and relationships in a dictionary representing a valid
+         STIX v2.1 Bundle object. https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_gms872kuzdmg
+        Use the newer_than parameter to filter articles that are newer than your last call.
+
+        :param session: The authenticated session to use to make the api calls
+        :param newer_than: Only articles newer than this parameter will be used. If None only one call will be make,
+         and the continuation will be ignored
+        """
+        self.newer_than = newer_than
+        self.session = session
+        self.session.api_host = "https://cloud.feedly.com"
+        self.user = self.session.user
+
+    def from_all_enterprise_categories(self) -> Dict:
+        return self.from_stream(self.user.get_all_enterprise_categories_stream())
+
+    def from_all_user_categories(self) -> Dict:
+        return self.from_stream(self.user.get_all_user_categories_stream())
+
+    def from_enterprise_category(self, name_or_id: str) -> Dict:
+        return self.from_stream(self.user.enterprise_categories.get(name_or_id))
+
+    def from_enterprise_tag(self, name_or_id: str) -> Dict:
+        return self.from_stream(self.user.enterprise_tags.get(name_or_id))
+
+    def from_user_category(self, name_or_id: str) -> Dict:
+        return self.from_stream(self.user.user_categories.get(name_or_id))
+
+    def from_stream(self, stream: Streamable) -> Dict:
+        return self.from_stream_id(stream.id)
+
+    def from_stream_id(self, stream_id: str) -> Dict:
+        return {
+            "objects": self._download_ioc_objects(stream_id=stream_id),
+            "id": f"bundle--{str(uuid.uuid4())}",
+            "type": "bundle",
+        }
+
+    def _download_ioc_objects(self, stream_id: str) -> List[Dict]:
+        objects = []
+        continuation = None
+        while True:
+            resp = self.session.make_api_request(
+                f"{self.RELATIVE_URL}",
+                params={
+                    "newerThan": int(self.newer_than.timestamp()) if self.newer_than else None,
+                    "continuation": continuation,
+                    "streamId": stream_id,
+                },
+            )
+            objects += resp.json()["objects"]
+            if not self.newer_than:
+                return objects
+            if "link" not in resp.headers:
+                return objects
+            next_url = resp.headers["link"][1:].split(">")[0]
+            continuation = parse_qs(next_url)["continuation"][0]

--- a/feedly/api_client/session.py
+++ b/feedly/api_client/session.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote_plus
 
 from requests import Response, Session
@@ -46,7 +46,12 @@ class FileAuthStore(Auth):
     a file based token storage scheme
     """
 
-    def __init__(self, token_dir: Path, client_id: str = "feedlydev", client_secret: str = "feedlydev"):
+    def __init__(
+        self,
+        token_dir: Path = Path.home() / ".config/feedly",
+        client_id: str = "feedlydev",
+        client_secret: str = "feedlydev",
+    ):
         """
 
         :param token_dir: the directory to store the tokens
@@ -73,13 +78,15 @@ class FileAuthStore(Auth):
 class FeedlySession(APIClient):
     def __init__(
         self,
-        auth: Union[str, Auth],
+        auth: Optional[Union[str, Auth]] = None,
         api_host: str = "https://feedly.com",
         user_id: str = None,
         client_name="feedly.python.client",
     ):
         """
-        :param auth: either the access token str to use when making requests or an Auth object to manage tokens
+        :param auth: either the access token str to use when making requests or an Auth object to manage tokens. If none
+         are passed, it is assumed that the token and refresh token are correcly setup in the `~/.config/feedly`
+         directory. You can run setup_auth.py in the examples to get setup.
         :param api_host: the feedly api server host.
         :param user_id: the user id to use when making requests. If not set, a request will be made to determine the user from the auth token.
         :param client_name: the name of your client, set this to something that can identify your app.
@@ -92,6 +99,8 @@ class FeedlySession(APIClient):
             token: str = auth
             auth = Auth()
             auth.auth_token = token
+        elif auth is None:
+            auth = FileAuthStore()
 
         self.auth: Auth = auth
         self.api_host: str = api_host

--- a/feedly/api_client/session.py
+++ b/feedly/api_client/session.py
@@ -18,6 +18,8 @@ from feedly.api_client.protocol import (
     UnauthorizedAPIError,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class Auth:
     """
@@ -240,9 +242,9 @@ class FeedlySession(APIClient):
                         if conn_error:
                             raise conn_error
                         else:
-                            logging.error(resp.json())
+                            logger.error(resp.json())
                             resp.raise_for_status()
-                    logging.warning("Error for %s: %s", relative_url, conn_error if conn_error else resp.text)
+                    logger.warning("Error for %s: %s", relative_url, conn_error if conn_error else resp.text)
                     time.sleep(2 ** (tries - 1))  # 1 second, then 2, 4, 8, etc.
         except HTTPError as e:
             code = e.response.status_code
@@ -268,7 +270,7 @@ class FeedlySession(APIClient):
                             relative_url=relative_url, method=method, data=data, timeout=timeout, max_tries=max_tries
                         )
                     except Exception as e2:
-                        logging.info("error refreshing access token", exc_info=e2)
+                        logger.info("error refreshing access token", exc_info=e2)
                         # fall through to raise auth error
                 raise UnauthorizedAPIError(e)
             elif code == 429:

--- a/feedly/api_client/stream.py
+++ b/feedly/api_client/stream.py
@@ -56,6 +56,12 @@ class StreamIdBase:
     def __str__(self):
         return self.__repr__()
 
+    def is_category(self):
+        return self.type == "category"
+
+    def is_tag(self):
+        return self.type == "tag"
+
 
 class UserStreamId(StreamIdBase):
     """
@@ -76,12 +82,6 @@ class UserStreamId(StreamIdBase):
 
         super().__init__(id_, STREAM_SOURCE_USER, parts[1], parts[2], "/".join(parts[3:]))
 
-    def is_category(self):
-        return self.type == "category"
-
-    def is_tag(self):
-        return self.type == "tag"
-
 
 class EnterpriseStreamId(StreamIdBase):
     def __init__(self, id_: str = None, parts: List[str] = None):
@@ -101,12 +101,6 @@ class EnterpriseStreamId(StreamIdBase):
             raise ValueError("not an enterprise stream: " + id_)
 
         super().__init__(id_, STREAM_SOURCE_ENTERPRISE, parts[1], parts[2], parts[3])
-
-    def is_category(self):
-        return self.type == "category"
-
-    def is_tag(self):
-        return self.type == "tag"
 
 
 class StreamOptions:

--- a/feedly/examples/enterprise/export_indicators_of_compromise_from_a_stream.py
+++ b/feedly/examples/enterprise/export_indicators_of_compromise_from_a_stream.py
@@ -1,0 +1,38 @@
+import json
+from datetime import datetime, timedelta
+from pprint import pprint
+
+from feedly.api_client.enterprise.indicators_of_compromise import IoCDownloader
+from feedly.api_client.session import FeedlySession
+from feedly.examples.utils import RESULTS_DIR, run_example
+
+
+def example_export_indicators_of_compromise_from_all_enterprise_feeds():
+    """
+    This example will save a STIX 2.1 bundle containing the contextualized IoCs that Leo extracted during the past 12
+     hours in all your enterprise feeds. 
+    """
+    # Authenticate using the default auth directory
+    session = FeedlySession()
+
+    # Create the IoC fetcher object, and limit it to 12 hours
+    # Usually newer_than will be the datetime of the last fetch
+    downloader = IoCDownloader(session=session, newer_than=datetime.now() - timedelta(hours=12))
+
+    # Fetch the IoC from all the enterprise categories, and create a bundle containing them
+    # You can use a different method to get the iocs from you personal categories, personal or enterprise boards,
+    #  or from specific categories/boards using their names or ids
+    iocs_bundle = downloader.from_all_enterprise_categories()
+
+    # Save the bundle in a file
+    with (RESULTS_DIR / "ioc_example.json").open("w") as f:
+        json.dump(iocs_bundle, f, indent=2)
+
+    # Console display
+    pprint(iocs_bundle)
+
+
+if __name__ == "__main__":
+    # Will prompt for the token if missing, and launch the example above
+    # If a token expired error is raised, will prompt for a new token and restart the example
+    run_example(example_export_indicators_of_compromise_from_all_enterprise_feeds)

--- a/feedly/examples/list_streams.py
+++ b/feedly/examples/list_streams.py
@@ -1,19 +1,16 @@
 from pprint import pprint
 
-from feedly.api_client.session import FeedlySession, FileAuthStore
-from feedly.examples.utils import AUTH_DIR
+from feedly.api_client.session import FeedlySession
+from feedly.examples.utils import run_example
 
-if __name__ == "__main__":
+
+def example_display_feeds_and_boards():
     """
-    You need to setup your auth directory as described in the README of the library.
-    Alternatively, you can remove the `FileAuthStore` usage and replace it by the token directly, but you'll need to do
-     it in every example .
-     
     This example will display your personal categories and tags.
-    Additionally, if you are part of an team, it will also display the enterprise ones.
+    Additionally, if you are part of a team, it will also display the enterprise ones.
     """
-    # Create the session using the auth directory
-    user = FeedlySession(auth=FileAuthStore(AUTH_DIR)).user
+    # Create the session using the default auth directory
+    user = FeedlySession().user
 
     # Display the personal categories and tags
     print("User categories:")
@@ -21,7 +18,6 @@ if __name__ == "__main__":
     print()
     print("User tags:")
     pprint(user.user_tags.name2stream)
-
     # Display the enterprise categories and tags, if part of a team
     if "enterpriseName" in user.json:
         print()
@@ -30,3 +26,9 @@ if __name__ == "__main__":
         print()
         print("Enterprise tags:")
         pprint(user.enterprise_tags.name2stream)
+
+
+if __name__ == "__main__":
+    # Will prompt for the token if missing, and launch the example above
+    # If a token expired error is raised, will prompt for a new token and restart the example
+    run_example(example_display_feeds_and_boards)

--- a/feedly/examples/list_streams.py
+++ b/feedly/examples/list_streams.py
@@ -1,0 +1,32 @@
+from pprint import pprint
+
+from feedly.api_client.session import FeedlySession, FileAuthStore
+from feedly.examples.utils import AUTH_DIR
+
+if __name__ == "__main__":
+    """
+    You need to setup your auth directory as described in the README of the library.
+    Alternatively, you can remove the `FileAuthStore` usage and replace it by the token directly, but you'll need to do
+     it in every example .
+     
+    This example will display your personal categories and tags.
+    Additionally, if you are part of an team, it will also display the enterprise ones.
+    """
+    # Create the session using the auth directory
+    user = FeedlySession(auth=FileAuthStore(AUTH_DIR)).user
+
+    # Display the personal categories and tags
+    print("User categories:")
+    pprint(user.user_categories.name2stream)
+    print()
+    print("User tags:")
+    pprint(user.user_tags.name2stream)
+
+    # Display the enterprise categories and tags, if part of a team
+    if "enterpriseName" in user.json:
+        print()
+        print("Enterprise categories:")
+        pprint(user.enterprise_categories.name2stream)
+        print()
+        print("Enterprise tags:")
+        pprint(user.enterprise_tags.name2stream)

--- a/feedly/examples/list_streams.py
+++ b/feedly/examples/list_streams.py
@@ -6,25 +6,25 @@ from feedly.examples.utils import run_example
 
 def example_display_feeds_and_boards():
     """
-    This example will display your personal categories and tags.
-    Additionally, if you are part of a team, it will also display the enterprise ones.
+    This example will display your personal feeds and boards.
+    Additionally, if you are part of a team, it will also display the team ones.
     """
     # Create the session using the default auth directory
     user = FeedlySession().user
 
     # Display the personal categories and tags
-    print("User categories:")
+    print("User feeds:")
     pprint(user.user_categories.name2stream)
     print()
-    print("User tags:")
+    print("User boards:")
     pprint(user.user_tags.name2stream)
     # Display the enterprise categories and tags, if part of a team
     if "enterpriseName" in user.json:
         print()
-        print("Enterprise categories:")
+        print("Team feeds:")
         pprint(user.enterprise_categories.name2stream)
         print()
-        print("Enterprise tags:")
+        print("Team boards:")
         pprint(user.enterprise_tags.name2stream)
 
 

--- a/feedly/examples/setup_auth.py
+++ b/feedly/examples/setup_auth.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def setup_auth(directory: Path = Path.home() / ".config/feedly", overwrite: bool = False):
+    directory.mkdir(exist_ok=True, parents=True)
+
+    auth_file = directory / "access.token"
+
+    if not auth_file.exists() or overwrite:
+        auth = input("Enter your token: ")
+        auth_file.write_text(auth.strip())
+
+
+if __name__ == "__main__":
+    setup_auth(overwrite=True)

--- a/feedly/examples/stream_entries.py
+++ b/feedly/examples/stream_entries.py
@@ -1,0 +1,27 @@
+from feedly.api_client.session import FeedlySession, FileAuthStore
+from feedly.api_client.stream import StreamOptions
+from feedly.examples.utils import AUTH_DIR
+
+if __name__ == "__main__":
+    """
+    You need to setup your auth directory as described in the README of the library.
+    Alternatively, you can remove the `FileAuthStore` usage and replace it by the token directly, but you'll need to do
+     it in every example .
+     
+    This example will prompt you to enter a category name, download the 10 latest articles from it, and display their
+     titles.
+    """
+    # Prompt for the category name/id to use
+    user_category_name_or_id = input("> User category name or id: ")
+
+    # Create the session using the auth directory
+    session = FeedlySession(auth=FileAuthStore(AUTH_DIR))
+
+    # Fetch the category by its name/id
+    # To use an enterprise category, change to `session.user.enterprise_categories`. Tags are also supported.
+    category = session.user.user_categories.get(user_category_name_or_id)
+
+    # Stream 10 articles with their contents from the category
+    for article in category.stream_contents(options=StreamOptions(max_count=10)):
+        # Print the title of each article
+        print(article["title"])

--- a/feedly/examples/stream_entries.py
+++ b/feedly/examples/stream_entries.py
@@ -1,21 +1,18 @@
-from feedly.api_client.session import FeedlySession, FileAuthStore
+from feedly.api_client.session import FeedlySession
 from feedly.api_client.stream import StreamOptions
-from feedly.examples.utils import AUTH_DIR
+from feedly.examples.utils import run_example
 
-if __name__ == "__main__":
+
+def example_stream_entries():
     """
-    You need to setup your auth directory as described in the README of the library.
-    Alternatively, you can remove the `FileAuthStore` usage and replace it by the token directly, but you'll need to do
-     it in every example .
-     
     This example will prompt you to enter a category name, download the 10 latest articles from it, and display their
      titles.
     """
     # Prompt for the category name/id to use
     user_category_name_or_id = input("> User category name or id: ")
 
-    # Create the session using the auth directory
-    session = FeedlySession(auth=FileAuthStore(AUTH_DIR))
+    # Create the session using the default auth directory
+    session = FeedlySession()
 
     # Fetch the category by its name/id
     # To use an enterprise category, change to `session.user.enterprise_categories`. Tags are also supported.
@@ -25,3 +22,9 @@ if __name__ == "__main__":
     for article in category.stream_contents(options=StreamOptions(max_count=10)):
         # Print the title of each article
         print(article["title"])
+
+
+if __name__ == "__main__":
+    # Will prompt for the token if missing, and launch the example above
+    # If a token expired error is raised, will prompt for a new token and restart the example
+    run_example(example_stream_entries)

--- a/feedly/examples/utils.py
+++ b/feedly/examples/utils.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+EXAMPLES_DIR = Path(__file__).parent
+AUTH_DIR = EXAMPLES_DIR / "auth"
+RESULTS_DIR = EXAMPLES_DIR / "results"
+
+RESULTS_DIR.mkdir(exist_ok=True)

--- a/feedly/examples/utils.py
+++ b/feedly/examples/utils.py
@@ -1,7 +1,26 @@
+import logging
 from pathlib import Path
+from typing import Callable
+
+from feedly.api_client.protocol import UnauthorizedAPIError
+from feedly.examples.setup_auth import setup_auth
 
 EXAMPLES_DIR = Path(__file__).parent
-AUTH_DIR = EXAMPLES_DIR / "auth"
 RESULTS_DIR = EXAMPLES_DIR / "results"
 
 RESULTS_DIR.mkdir(exist_ok=True)
+
+
+def run_example(f: Callable) -> None:
+    setup_auth()
+    try:
+        f()
+        return
+    except UnauthorizedAPIError as e:
+        if "token expired" not in e.response.text:
+            raise e
+
+        logging.warning("Expired token. Please enter a new valid token.")
+        setup_auth(overwrite=True)
+
+        f()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.19.1
+backports.cached-property==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -9,19 +9,19 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, setup
 
 # Package meta-data.
-NAME = 'feedly-client'
-DESCRIPTION = 'A lightweight client for the feedly api (https://developers.feedly.com).'
-URL = 'https://github.com/feedly/python-api-client'
-EMAIL = 'kireet@feedly.com'
-AUTHOR = 'Kireet'
-REQUIRES_PYTHON = '>=3.6.0'
-VERSION = '0.22'
+NAME = "feedly-client"
+DESCRIPTION = "A lightweight client for the feedly api (https://developers.feedly.com)."
+URL = "https://github.com/feedly/python-api-client"
+EMAIL = "kireet@feedly.com"
+AUTHOR = "Kireet"
+REQUIRES_PYTHON = ">=3.6.0"
+VERSION = "0.23"
 
 # What packages are required for this module to be executed?
-with open('requirements.txt') as f:
+with open("requirements.txt") as f:
     REQUIRED = f.read().splitlines()
 
 
@@ -40,30 +40,30 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
 try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-        long_description = '\n' + f.read()
+    with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+        long_description = "\n" + f.read()
 except FileNotFoundError:
     long_description = DESCRIPTION
 
 # Load the package's __version__.py module as a dictionary.
 about = {}
 if not VERSION:
-    with open(os.path.join(here, NAME, '__version__.py')) as f:
+    with open(os.path.join(here, NAME, "__version__.py")) as f:
         exec(f.read(), about)
 else:
-    about['__version__'] = VERSION
+    about["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []
 
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print("\033[1m{0}\033[0m".format(s))
 
     def initialize_options(self):
         pass
@@ -73,20 +73,20 @@ class UploadCommand(Command):
 
     def run(self):
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(here, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(here, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
 
-        self.status('Uploading the package to PyPI via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPI via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(about['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system("git tag v{0}".format(about["__version__"]))
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -94,37 +94,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about['__version__'],
+    version=about["__version__"],
     description=DESCRIPTION,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=['feedly.api_client'],
+    packages=["feedly.api_client"],
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand,},
 )


### PR DESCRIPTION
 - Factorizing the behaviour to lazily get streams in the `FeedlyUser` class. I wanted to add support to get the stream by names but with the previous caching system it needed to be done in 4 places
 - Adding 2 simple examples:
   - Streaming entries
   - Listing categories and tags