### PR TITLE
Feat: make use of ranked sorting when streaming

### DIFF
--- a/feedly/api_client/stream.py
+++ b/feedly/api_client/stream.py
@@ -110,9 +110,9 @@ class StreamOptions:
     to produce url parameters
     """
 
-    def __init__(self, max_count: int = 100):
+    def __init__(self, max_count: int = 100, ranked: str = "newest"):
         self.count: int = 20
-        self.ranked: str = "newest"
+        self.ranked: str = ranked
         self.unreadOnly: bool = False
         self.newerThan: int = None
         self._max_count = max_count

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = "https://github.com/feedly/python-api-client"
 EMAIL = "ml@feedly.com"
 AUTHOR = "Feedly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.24"
+VERSION = "0.25"
 
 # What packages are required for this module to be executed?
 with open("requirements.txt") as f:


### PR DESCRIPTION
Adds a `ranked` argument ("newest"|"oldest") when streaming items